### PR TITLE
fix/seed

### DIFF
--- a/app-near/scripts/seeds/su.ts
+++ b/app-near/scripts/seeds/su.ts
@@ -31,8 +31,8 @@ const getAnswerQuantity = (
     case SurveyCase.MORE_THAN_CATEGORIES_TARGETS:
     case SurveyCase.MORE_THAN_GLOBAL_TARGET:
       return faker.number.int({
-        min: surveyTarget + Math.floor(surveyTarget / 2),
-        max: 2 * surveyTarget,
+        min: 5 * surveyTarget,
+        max: 10 * surveyTarget,
       });
     default:
       return 0;


### PR DESCRIPTION
Mini pull-request. Depuis qu'on a baissé le seuil à 1,5 pour la représentativité, il faut générer plus de données pour respecter ce seuil (modèle de probabilité qui fait que plus on a de données, plus on tend vers la cible qu'on s'est fixé)